### PR TITLE
Make logo and header text link to the homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
   <body>
     <nav class="top-menu">
       <div class="container-fluid main-container">
-        <img src="/assets/images/st2-logo.png" alt="StackStorm" height="35" width="147" />
+        <a href="https://exchange.stackstorm.org/"><img src="/assets/images/st2-logo.png" alt="StackStorm" height="35" width="147" /></a>
         <ul class="row">
           <li id="pack-create"></li>
           <li id="pack-submit"></li>
@@ -26,7 +26,7 @@
       <div class="container-fluid main-container">
         <div class="row">
           <div class="col-md-8 offset-md-2 content">
-            <h1 class="header"><span>Stack</span>Storm Exchange</h1>
+            <h1 class="header"><a href="https://exchange.stackstorm.org/"><span>Stack</span>Storm Exchange</a></h1>
             <p class="large">Automate all the things you already know and use<br/>with dozens of ready-made integration packs.</p>
             <p class="large">Cloud providers, monitoring services, lightbulbs.</p>
             <pre class="code">st2 pack install <span id="pack-install">mypack</span></pre>


### PR DESCRIPTION
The title says it all.

I haven't been able to test it locally yet since `npm run build` fails - https://gist.github.com/Kami/f2e1f2837983338cc778b1ec27b75bbf.