### PR TITLE
Fix icons for some packs

### DIFF
--- a/src/components/PackView.jsx
+++ b/src/components/PackView.jsx
@@ -83,7 +83,7 @@ const PackKeywords = React.createClass({
 const PackIcon = React.createClass({
   getInitialState() {
     return {
-      image_url: `https://index.stackstorm.org/v1/icons/${this.props.name}.png`,
+      image_url: `https://index.stackstorm.org/v1/icons/${this.props.ref}.png`,
     };
   },
   useDefault() {


### PR DESCRIPTION
We need to use `ref` not `name` attribute since icons are named using `ref`, not `name`.