### PR TITLE
Add info about supported Python version and Circle CI link to the pack card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
 
     <footer>
       <div class="container-fluid main-container">
-        © 2017 StackStorm <span class="heart">❤️</span>
+        © 2015-2019 StackStorm <span class="heart">❤️</span>
         <ul class="footer-nav">
           <li>
             <a href="https://stackstorm.org" target="_blank">

--- a/src/components/PackView.jsx
+++ b/src/components/PackView.jsx
@@ -16,6 +16,24 @@ const Pack = React.createClass({
     setTimeout((() => { target.removeClass('copied'); }), 1000);
   },
   render() {
+    // If no explicit version is specified, we assume it only works with Python 2.x
+    var supported_python_versions = [];
+    var supported_python_versions_string;
+
+    if (!this.props.python_versions || this.props.python_versions.length === 0) {
+      supported_python_versions_string = 'Python 2.x';
+    }
+    else {
+      if (this.props.python_versions.indexOf('2') > -1) {
+        supported_python_versions.push('Python 2.x')
+      }
+      if (this.props.python_versions.indexOf('3') > -1) {
+        supported_python_versions.push('Python 3.x')
+      }
+
+      supported_python_versions_string = supported_python_versions.join(', ');
+    }
+
     return (
       <div className="card pack">
         <div className="card-header">
@@ -50,6 +68,11 @@ const Pack = React.createClass({
                 : '' }
             </div>
             <div className="author">{this.props.author}</div>
+          </div>
+          <div className="row">
+          <div className="python_versions">
+              Supported Python versions: { supported_python_versions_string }
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/PackView.jsx
+++ b/src/components/PackView.jsx
@@ -44,6 +44,9 @@ const Pack = React.createClass({
           <a
             className="btn btn-sm btn-github" href={this.props.repo_url}
             rel="noopener noreferrer" target="_blank"
+            data-title="View source code on Github"
+            data-placement="bottom"
+            data-toggle="tooltip"
           ><i className="fa fa-github" /></a>
           <a
             rel="button" tabIndex="-1" className="btn btn-sm btn-copy"
@@ -53,7 +56,14 @@ const Pack = React.createClass({
             data-placement="bottom"
             data-toggle="tooltip"
             onClick={this.copyCommand}
-          ><i className="fa fa-paste" /></a>
+            ><i className="fa fa-paste" /></a>
+          <a
+            className="btn btn-sm btn-circleci" href={`https://circleci.com/gh/StackStorm-Exchange/stackstorm-${this.props.slug}`}
+            rel="noopener noreferrer" target="_blank"
+            data-title="View build status on Circle CI"
+            data-placement="bottom"
+            data-toggle="tooltip"
+          ><i className="fa fa-cogs" /></a>
         </div>
         <div className="card-block description">
           {this.props.children}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -192,7 +192,8 @@ body {
 
   .card-footer {
     .author,
-    .version {
+    .version,
+    .python_versions {
       margin: 0 15px;
 
       font-size: 12px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -130,7 +130,7 @@ body {
     .btn {
       position: absolute;
       top: 16px;
-      right: 55px;
+      right: 95px;
 
       width: 30px;
       height: 25px;
@@ -157,6 +157,12 @@ body {
       }
 
       &.btn-github {
+        right: 55px;
+
+        line-height: 24px;
+      };
+
+      &.btn-circleci {
         right: 15px;
 
         line-height: 24px;


### PR DESCRIPTION
This pull request includes various changes:

1. Update copyright year
2. Add information about supported Python versions to the footer of the pack card. If `supported_versions` attribute is not explicitly specified in pack metadata file, we assume it only works with Python 2.x (aka current default behavior).
3. Add link to the Circle CI build page to the pack card. This allows users to easily view pack build status on Circle CI.

NOTE: The process of updating pack metadata with the new ``python_versions`` attribute is still on going and will take a while.

## Preview:

Pack which explicitly declares support for Python 2.x and 3.x:

![screenshot from 2019-01-09 11-03-35](https://user-images.githubusercontent.com/125088/50892265-5cbcaa80-13fe-11e9-8395-91464ee01a65.png)

Pack which doesn't contain that attribute in the pack metadata file:

![screenshot from 2019-01-09 11-03-47](https://user-images.githubusercontent.com/125088/50892267-5e866e00-13fe-11e9-9243-e500083aca46.png)
