### PR TITLE
fix pack display word wrapping

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ import { render } from 'react-dom';
 import React from 'react';
 
 import './styles/main.scss';
+import './styles/customizations.scss';
 import './components/vendor/analytics';
 
 import Conveyor from './components/Conveyor';

--- a/src/styles/customizations.scss
+++ b/src/styles/customizations.scss
@@ -1,0 +1,1 @@
+.card-title { max-width: 118px }


### PR DESCRIPTION
Fix the word wrap on longer pack names.

![image](https://user-images.githubusercontent.com/1099386/72813903-254c2500-3c32-11ea-95af-5453060e0152.png)


