### PR TITLE
patch eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-eslint": "10.0.1",
     "babel-loader": "^8.0.6",
     "css-loader": "=0.25.0",
-    "eslint": "^6.0.1",
+    "eslint": "^6.6.0",
     "eslint-plugin-react": "^7.14.2",
     "file-loader": "=0.9.0",
     "imports-loader": "=0.6.5",


### PR DESCRIPTION
* Update `eslint` to 6.6.0 to patch vuln in `eslint-utils`. Tested and gets us to `eslint-utils>=1.4.3`